### PR TITLE
Add FinanceToolkit YahooFinance enforcement

### DIFF
--- a/feature_engineer.py
+++ b/feature_engineer.py
@@ -8,7 +8,12 @@ def engineer(ticker:str):
     df = pd.read_csv(RAW_DIR/f"{ticker}.csv",index_col=0,parse_dates=True)
     df_ta = ta.strategy(ta.Strategy(name='all',talib=False),df.copy())
     df = pd.concat([df, df_ta], axis=1).dropna()
-    tk = Toolkit(ticker, start=df.index.min(), end=df.index.max())
+    tk = Toolkit(
+        ticker,
+        start=df.index.min(),
+        end=df.index.max(),
+        enforce_source="YahooFinance",
+    )
     funda = tk.ratios.collect().ffill().reindex(df.index)
     df = pd.concat([df, funda], axis=1).dropna()
     out = PROC_DIR/f"{ticker}.parquet"


### PR DESCRIPTION
## Summary
- ensure FinanceToolkit uses YahooFinance as the data source in feature engineering

## Testing
- `python feature_engineer.py` *(fails: No module named 'numpy.NaN')*

------
https://chatgpt.com/codex/tasks/task_e_68408a2eac68832d8b519640b6358900