### PR TITLE
Add numpy import to cae_model

### DIFF
--- a/cae_model.py
+++ b/cae_model.py
@@ -1,6 +1,7 @@
 
 import tensorflow as tf
 from tensorflow.keras import layers, Model
+import numpy as np
 from ..config import WINDOW_LENGTH, LATENT_DIM
 
 def build_cae(n_features:int):


### PR DESCRIPTION
## Summary
- add missing NumPy import near TensorFlow imports in `cae_model.py`

## Testing
- `python -m py_compile cae_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b1f48ef8832daacb4f38a80f4bc6