### PR TITLE
Load tickers from new CSV

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,8 @@ RAW_DIR         = DATA_DIR / "raw"
 PROC_DIR        = DATA_DIR / "processed"
 LOG_DIR         = ROOT_DIR / "logs"
 
-TICKER_FILE     = DATA_DIR / "snp.csv"
+# CSV listing tickers to download. Only the first column is used.
+TICKER_FILE     = ROOT_DIR / "snp.csv"
 START_DATE      = "2015-01-01"
 END_DATE        = "2024-12-31"
 

--- a/src/data/downloader.py
+++ b/src/data/downloader.py
@@ -19,7 +19,14 @@ def download(ticker:str):
     data.to_csv(out)
 
 def batch():
-    tickers = pd.read_csv(TICKER_FILE,header=None)[0].tolist()
+    # The snp.csv file may contain additional columns; only the first column
+    # with ticker symbols should be used.
+    tickers = (
+        pd.read_csv(TICKER_FILE, usecols=[0])
+          .iloc[:, 0]
+          .dropna()
+          .tolist()
+    )
     for t in tickers:
         print('↓',t)
         download(t.strip())


### PR DESCRIPTION
## Summary
- look for snp tickers at repository root
- read only the first column of `snp.csv` when downloading data

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6840f15a0a84832dbe1d7aa0cec9e259