### PR TITLE
Fix quick start folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ End‑to‑end research pipeline that discovers statistical‑arbitrage pairs in
 ## Quick start
 
 ```bash
-git clone <your‑fork> pairs_trading_system
-cd pairs_trading_system
+git clone <your‑fork> pairs
+cd pairs
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 python scripts/run_full_pipeline.py


### PR DESCRIPTION
## Summary
- fix README quick start instructions to clone repo into `pairs`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840f3303390832d85b7df3f6f39e847