### PR TITLE
Fix FinanceToolkit and fiscal quarter alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ python scripts/run_full_pipeline.py
 
 ## Pipeline Overview
 
-1. **Data collection** → daily OHLCV + fundamentals (FinanceToolkit) aligned to quarter‑ends  
+1. **Data collection** → daily OHLCV + fundamentals (FinanceToolkit) aligned to fiscal quarter‑ends
 2. **Pre‑processing** → technical indicators + scaling + 60‑day windows  
 3. **CAE training** (TensorFlow/Keras, 500 epochs) → 10‑D latent factors  
 4. **Clustering** (Ward, k=10) → pick 15 closest pairs/cluster  

--- a/src/data/downloader.py
+++ b/src/data/downloader.py
@@ -1,19 +1,19 @@
 
-"""Download OHLCV and align to quarter‑end."""
+"""Download daily OHLCV data."""
 import pandas as pd, yfinance as yf
 from pathlib import Path
 from ..config import RAW_DIR, START_DATE, END_DATE, TICKER_FILE
 
-def align_to_quarter_end(df):
-    df = df.resample("B").ffill()
-    return df.loc[df.index.isin(df.resample("Q").last().index)]
+def _fill_missing_days(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure continuous business-day index for later alignment."""
+    return df.resample("B").ffill()
 
 def download(ticker:str):
-    data = yf.download(ticker,start=START_DATE,end=END_DATE,progress=False)
+    data = yf.download(ticker, start=START_DATE, end=END_DATE, progress=False)
     if data.empty:
         print(f"No data for {ticker}")
         return
-    data = align_to_quarter_end(data)
+    data = _fill_missing_days(data)
     out = RAW_DIR/f"{ticker}.csv"
     out.parent.mkdir(parents=True,exist_ok=True)
     data.to_csv(out)

--- a/src/data/feature_engineer.py
+++ b/src/data/feature_engineer.py
@@ -5,16 +5,20 @@ from financetoolkit import Toolkit
 from ..config import RAW_DIR, PROC_DIR
 
 def engineer(ticker:str):
-    df = pd.read_csv(RAW_DIR/f"{ticker}.csv",index_col=0,parse_dates=True)
+    df = pd.read_csv(RAW_DIR/f"{ticker}.csv", index_col=0, parse_dates=True)
     df.ta.strategy(ta.Strategy(name="all", talib=False))
     df = df.dropna()
+
     tk = Toolkit(
-        ticker,
+        [ticker],  # FinanceToolkit expects a list
         start=df.index.min(),
         end=df.index.max(),
         enforce_source="YahooFinance",
     )
-    funda = tk.ratios.collect().ffill().reindex(df.index)
+
+    funda = tk.ratios.collect().ffill()
+
+    df = df.reindex(funda.index).ffill()
     df = pd.concat([df, funda], axis=1).dropna()
     out = PROC_DIR/f"{ticker}.parquet"
     out.parent.mkdir(parents=True,exist_ok=True)


### PR DESCRIPTION
## Summary
- use a list when creating `Toolkit`
- align OHLCV data to fundamentals' fiscal quarters
- clarify README about fiscal quarter alignment

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840f39ac004832d9f524933031fec5c