### PR TITLE
Aggregate latents by ticker

### DIFF
--- a/src/autoencoder/train_cae.py
+++ b/src/autoencoder/train_cae.py
@@ -1,4 +1,5 @@
 
+import json
 import numpy as np
 import pandas as pd
 from ..config import PROC_DIR, CAE_EPOCHS, CAE_BATCH_SIZE, LOG_DIR
@@ -8,23 +9,48 @@ from ..data.scaler import fit_scaler
 
 def train_cae():
     scaler = fit_scaler()
-    dfs = [pd.read_parquet(p) for p in PROC_DIR.glob("*.parquet")]
+    files = sorted(PROC_DIR.glob("*.parquet"))
+    dfs = [pd.read_parquet(p) for p in files]
     X = pd.concat(dfs).dropna()
     X = scaler.transform(X)
     n_features = X.shape[1]
-    windows=[]
-    idx=0
+    windows = []
+    lengths = []
+    idx = 0
     for df in dfs:
-        w=build_windows(pd.DataFrame(X[idx:idx+len(df)],index=df.index))
+        w = build_windows(pd.DataFrame(X[idx:idx + len(df)], index=df.index))
         windows.append(w)
-        idx+=len(df)
-    Xw = np.concatenate(windows,axis=0)
+        lengths.append(len(w))
+        idx += len(df)
+    Xw = np.concatenate(windows, axis=0)
     Xw = Xw[...,np.newaxis]  # add channel dim
 
     model, encoder = build_cae(n_features)
     LOG_DIR.mkdir(parents=True, exist_ok=True)
-    history = model.fit(Xw, Xw, epochs=CAE_EPOCHS, batch_size=CAE_BATCH_SIZE, validation_split=0.1)
-    model.save(LOG_DIR/'cae.h5')
-    encoder.save(LOG_DIR/'encoder.h5')
-    np.save(LOG_DIR/'latent.npy', encoder.predict(Xw))
+    history = model.fit(
+        Xw,
+        Xw,
+        epochs=CAE_EPOCHS,
+        batch_size=CAE_BATCH_SIZE,
+        validation_split=0.1,
+    )
+    model.save(LOG_DIR / "cae.h5")
+    encoder.save(LOG_DIR / "encoder.h5")
+
+    latent = encoder.predict(Xw)
+    np.save(LOG_DIR / "latent.npy", latent)
+
+    # Aggregate latent vectors per ticker to obtain one vector per stock
+    start = 0
+    agg = []
+    for l in lengths:
+        agg.append(latent[start : start + l].mean(axis=0))
+        start += l
+    ticker_latent = np.stack(agg, axis=0)
+    np.save(LOG_DIR / "ticker_latent.npy", ticker_latent)
+
+    tickers = [p.stem for p in files]
+    with open(LOG_DIR / "ticker_index.json", "w") as f:
+        json.dump(tickers, f)
+
     return history

--- a/src/clustering/cluster_utils.py
+++ b/src/clustering/cluster_utils.py
@@ -4,7 +4,7 @@ from sklearn.cluster import AgglomerativeClustering
 from ..config import N_CLUSTERS, LOG_DIR
 
 def cluster_latents():
-    Z = np.load(LOG_DIR/'latent.npy')
+    Z = np.load(LOG_DIR / 'ticker_latent.npy')
     clust = AgglomerativeClustering(n_clusters=N_CLUSTERS, linkage='ward')
     labels = clust.fit_predict(Z)
     np.save(LOG_DIR/'labels.npy', labels)

--- a/src/clustering/select_pairs.py
+++ b/src/clustering/select_pairs.py
@@ -1,18 +1,24 @@
 
+import json
 import numpy as np
 from scipy.spatial.distance import cdist
 from ..config import PAIRS_PER_CLUST, LOG_DIR
 
 def select_pairs():
-    Z = np.load(LOG_DIR/'latent.npy')
-    labels = np.load(LOG_DIR/'labels.npy')
-    pairs=[]
+    Z = np.load(LOG_DIR / 'ticker_latent.npy')
+    labels = np.load(LOG_DIR / 'labels.npy')
+    with open(LOG_DIR / 'ticker_index.json') as f:
+        tickers = json.load(f)
+
+    pairs = []
     for c in set(labels):
         idx = np.where(labels==c)[0]
         dists = cdist(Z[idx], Z[idx], metric='euclidean')
         triu = np.triu_indices_from(dists, k=1)
         sorted_pairs = sorted(zip(triu[0],triu[1],dists[triu]), key=lambda x:x[2])
         top = sorted_pairs[:PAIRS_PER_CLUST]
-        pairs.extend([(idx[i], idx[j]) for i,j,_ in top])
-    np.save(LOG_DIR/'pairs.npy', pairs)
+        pairs.extend([(tickers[idx[i]], tickers[idx[j]]) for i, j, _ in top])
+
+    # Save as numpy array of strings for later steps
+    np.save(LOG_DIR / 'pairs.npy', np.array(pairs, dtype=object))
     return pairs


### PR DESCRIPTION
## Summary
- compute windows by file order and aggregate latent vectors per ticker
- persist per-ticker latents and ticker index mapping
- cluster tickers rather than windows
- output selected pairs as ticker strings

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_684110635ed0832d99db68d79eb8fba7