### PR TITLE
Add penalty for RL position flips

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python scripts/run_full_pipeline.py
 2. **Pre‑processing** → technical indicators + scaling + 60‑day windows  
 3. **CAE training** (TensorFlow/Keras, 500 epochs) → 10‑D latent factors  
 4. **Clustering** (Ward, k=10) → pick 15 closest pairs/cluster  
-5. **RL training** (PPO) – *reward = ΔPnL*  
+5. **RL training** (PPO) – *reward = ΔPnL*, with a small penalty for switching directly from long to short (or vice versa)
 6. **Backtest** → PnL, annual %, beta, alpha, MDD, Sharpe, Sortino, Calmar  
 
 All notebooks under `/notebooks` are executable in order and call the production code in `src/`.

--- a/src/config.py
+++ b/src/config.py
@@ -24,6 +24,7 @@ PAIRS_PER_CLUST = 15
 
 INIT_CAPITAL    = 1_000
 RL_ALGO         = "PPO"
+SWITCH_PENALTY  = 0.1
 
 TRADE_FREQUENCY = "1D"
 METRICS = ["total_pnl","annual_return","beta","alpha","max_drawdown","sharpe","sortino","calmar"]

--- a/src/rl/envs.py
+++ b/src/rl/envs.py
@@ -2,7 +2,7 @@
 import gymnasium as gym
 from gymnasium import spaces
 import numpy as np
-from ..config import INIT_CAPITAL, WINDOW_LENGTH
+from ..config import INIT_CAPITAL, WINDOW_LENGTH, SWITCH_PENALTY
 
 class PairTradingEnv(gym.Env):
     """Simple PnL reward: Δ(PnL) given discrete actions."""
@@ -26,7 +26,10 @@ class PairTradingEnv(gym.Env):
         obs = self.spread[self.t-WINDOW_LENGTH:self.t]
         pnl = prev_position * (self.spread[self.t-1] - prev_spread)
         reward = pnl
-        self.position = {0:0,1:1,2:-1}[action]
+        new_position = {0:0,1:1,2:-1}[action]
+        if prev_position * new_position == -1:
+            reward -= SWITCH_PENALTY
+        self.position = new_position
         info = {'pnl': pnl}
         return obs.astype(np.float32), reward, done, False, info
 


### PR DESCRIPTION
## Summary
- discourage rapid position changes by adding `SWITCH_PENALTY`
- apply penalty inside `PairTradingEnv`
- document new RL reward behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f181c840832db99aca2aa81b960e