### PR TITLE
Refactor CAE with 1D conv

### DIFF
--- a/src/autoencoder/cae_model.py
+++ b/src/autoencoder/cae_model.py
@@ -4,23 +4,26 @@ from tensorflow.keras import layers, Model
 import numpy as np
 from ..config import WINDOW_LENGTH, LATENT_DIM
 
-def build_cae(n_features:int):
-    inputs = layers.Input(shape=(WINDOW_LENGTH, n_features, 1))
-    x = layers.Conv2D(32,(3,3),activation='relu',padding='same')(inputs)
-    x = layers.MaxPool2D((2,2))(x)
-    x = layers.Conv2D(64,(3,3),activation='relu',padding='same')(x)
-    x = layers.MaxPool2D((2,2))(x)
+def build_cae(n_features: int):
+    """Build a simple convolutional autoencoder using 1D convolutions."""
+    inputs = layers.Input(shape=(WINDOW_LENGTH, n_features))
+
+    # Encoder
+    x = layers.Conv1D(32, 3, activation="relu", padding="same")(inputs)
+    x = layers.MaxPool1D(2)(x)
+    x = layers.Conv1D(64, 3, activation="relu", padding="same")(x)
+    x = layers.MaxPool1D(2)(x)
     shape = tf.keras.backend.int_shape(x)
     x = layers.Flatten()(x)
-    latent = layers.Dense(LATENT_DIM,name='latent')(x)
+    latent = layers.Dense(LATENT_DIM, name="latent")(x)
 
     # Decoder
-    x = layers.Dense(np.prod(shape[1:]),activation='relu')(latent)
+    x = layers.Dense(np.prod(shape[1:]), activation="relu")(latent)
     x = layers.Reshape(shape[1:])(x)
-    x = layers.UpSampling2D((2,2))(x)
-    x = layers.Conv2DTranspose(32,(3,3),activation='relu',padding='same')(x)
-    x = layers.UpSampling2D((2,2))(x)
-    outputs = layers.Conv2DTranspose(1,(3,3),activation='linear',padding='same')(x)
+    x = layers.UpSampling1D(2)(x)
+    x = layers.Conv1DTranspose(32, 3, activation="relu", padding="same")(x)
+    x = layers.UpSampling1D(2)(x)
+    outputs = layers.Conv1DTranspose(n_features, 3, activation="linear", padding="same")(x)
 
     model = Model(inputs,outputs)
     encoder = Model(inputs,latent)

--- a/src/autoencoder/train_cae.py
+++ b/src/autoencoder/train_cae.py
@@ -23,7 +23,6 @@ def train_cae():
         lengths.append(len(w))
         idx += len(df)
     Xw = np.concatenate(windows, axis=0)
-    Xw = Xw[...,np.newaxis]  # add channel dim
 
     model, encoder = build_cae(n_features)
     LOG_DIR.mkdir(parents=True, exist_ok=True)

--- a/src/autoencoder/train_cae.py
+++ b/src/autoencoder/train_cae.py
@@ -8,6 +8,7 @@ from ..data.window_builder import build_windows
 from ..data.scaler import fit_scaler
 
 def train_cae():
+    """Train the convolutional autoencoder and save latent factors."""
     scaler = fit_scaler()
     files = sorted(PROC_DIR.glob("*.parquet"))
     dfs = [pd.read_parquet(p) for p in files]


### PR DESCRIPTION
## Summary
- update CAE to use 1D convolutional layers
- drop unused channel dimension when training

## Testing
- `python -m py_compile src/autoencoder/cae_model.py src/autoencoder/train_cae.py`

------
https://chatgpt.com/codex/tasks/task_e_6841f1fbe1ec832d853f8d7c0430e396