### PR TITLE
Implement recency-weighted CAE aggregation

### DIFF
--- a/src/autoencoder/train_cae.py
+++ b/src/autoencoder/train_cae.py
@@ -6,8 +6,42 @@ from .cae_model import build_cae
 from ..data.window_builder import build_windows
 from ..data.scaler import fit_scaler
 
-def train_cae(window_length: int = WINDOW_LENGTH, latent_dim: int = LATENT_DIM, save: bool = True):
-    """Train the CAE and return latent representations."""
+
+def _exp_weights(n: int, alpha: float) -> np.ndarray:
+    """Return exponentially decaying weights with emphasis on recent samples."""
+    w = alpha ** np.arange(n)[::-1]
+    return w / w.sum()
+
+def train_cae(
+    window_length: int = WINDOW_LENGTH,
+    latent_dim: int = LATENT_DIM,
+    save: bool = True,
+    recency_alpha: float = 0.9,
+):
+    """Train the CAE and return latent representations.
+
+    Parameters
+    ----------
+    window_length : int
+        Length of each input window.
+    latent_dim : int
+        Dimension of the latent space.
+    save : bool
+        If ``True`` saves the model and embeddings to ``LOG_DIR``.
+    recency_alpha : float
+        Exponential decay factor for recency weighting. Values closer to 1 give
+        more emphasis to recent windows.
+
+    Returns
+    -------
+    list[np.ndarray]
+        Window level latent vectors for each ticker.
+    np.ndarray
+        Array of shape ``(n_tickers, latent_dim * 2)`` containing the weighted
+        mean and variance for each ticker.
+    History
+        Training history returned by ``model.fit``.
+    """
     scaler = fit_scaler()
     files = sorted(PROC_DIR.glob("*.parquet"))
     dfs = [pd.read_parquet(p) for p in files]
@@ -46,11 +80,17 @@ def train_cae(window_length: int = WINDOW_LENGTH, latent_dim: int = LATENT_DIM, 
     if save:
         np.save(LOG_DIR / "latent.npy", latent)
 
-    # Aggregate latent vectors per ticker to obtain one vector per stock
+    # Keep window level embeddings grouped by ticker
     start = 0
+    ticker_windows_latent: list[np.ndarray] = []
     agg = []
     for l in lengths:
-        agg.append(latent[start: start + l].mean(axis=0))
+        lw = latent[start : start + l]
+        ticker_windows_latent.append(lw)
+        weights = _exp_weights(l, recency_alpha)
+        mean = np.average(lw, axis=0, weights=weights)
+        var = np.average((lw - mean) ** 2, axis=0, weights=weights)
+        agg.append(np.concatenate([mean, var]))
         start += l
     ticker_latent = np.stack(agg, axis=0)
     if save:
@@ -61,4 +101,4 @@ def train_cae(window_length: int = WINDOW_LENGTH, latent_dim: int = LATENT_DIM, 
         with open(LOG_DIR / "ticker_index.json", "w") as f:
             json.dump(tickers, f)
 
-    return latent, ticker_latent, history
+    return ticker_windows_latent, ticker_latent, history


### PR DESCRIPTION
## Summary
- compute window embeddings grouped per ticker
- calculate ticker-level mean and variance with exponential recency weights
- update CAE training return value to preserve window-level embeddings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841fb80b65c832d80e0e2f0f33391df