### PR TITLE
Add metric stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,7 @@ python scripts/run_full_pipeline.py
 
 The RL agent training and backtesting steps currently contain placeholder
 implementations and are intended as starting points for further development.
+Backtesting metrics in `src.backtest.metrics` are likewise stubs awaiting full
+implementation.
 
 ---

--- a/src/backtest/metrics.py
+++ b/src/backtest/metrics.py
@@ -1,3 +1,5 @@
+"""Financial metrics utilities (currently placeholders)."""
+
 
 def sharpe(returns,rf=0):
     import numpy as np
@@ -5,3 +7,38 @@ def sharpe(returns,rf=0):
     return np.mean(excess)/np.std(excess,ddof=1)
 
 # add other metrics...
+
+
+def total_pnl(trades):
+    """Total profit and loss across all trades."""
+    raise NotImplementedError("total_pnl metric not implemented")
+
+
+def annual_return(equity_curve):
+    """Annualized return based on an equity curve."""
+    raise NotImplementedError("annual_return metric not implemented")
+
+
+def beta(returns, benchmark_returns):
+    """Risk beta relative to a benchmark."""
+    raise NotImplementedError("beta metric not implemented")
+
+
+def alpha(returns, benchmark_returns, rf=0):
+    """Risk-adjusted alpha relative to a benchmark."""
+    raise NotImplementedError("alpha metric not implemented")
+
+
+def max_drawdown(equity_curve):
+    """Maximum observed drawdown."""
+    raise NotImplementedError("max_drawdown metric not implemented")
+
+
+def sortino(returns, rf=0):
+    """Sortino ratio using downside volatility."""
+    raise NotImplementedError("sortino metric not implemented")
+
+
+def calmar(returns):
+    """Calmar ratio based on annual return and drawdown."""
+    raise NotImplementedError("calmar metric not implemented")


### PR DESCRIPTION
## Summary
- note that metrics are placeholders in README
- add several metric stubs raising `NotImplementedError`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841ff4c6ac4832d960f85414e5cf8d9