### PR TITLE
Implement backtesting engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ python scripts/run_full_pipeline.py
 6. **Train agents** on each pair through `src.rl.train_agent.train_all_pairs`.
 7. **Backtest results** with `src.backtest.backtester.run_backtests`.
 
-The RL agent training and backtesting steps currently contain placeholder
-implementations and are intended as starting points for further development.
-Backtesting metrics in `src.backtest.metrics` are likewise stubs awaiting full
-implementation.
+The RL training script uses a lightweight configuration suitable for quick
+experiments. Backtests leverage **Backtesting.py** via
+`src.backtest.backtester.run_backtests`, and a collection of common financial
+metrics is provided in `src.backtest.metrics`.
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ seaborn>=0.13
 tqdm>=4.66
 python-dotenv>=1.0
 optuna>=3.6
+backtesting>=0.3.3

--- a/src/backtest/backtester.py
+++ b/src/backtest/backtester.py
@@ -1,17 +1,125 @@
 
-# TODO: Implement full backtesting engine using stored pair data and
-# RL policy outputs. This placeholder simply marks where the
-# backtesting logic should go.
+"""Utilities for running RL policy backtests with Backtesting.py."""
 
-def run_backtests():
-    """Run offline backtests for trained policies.
+from pathlib import Path
+from typing import Iterable
 
-    Expected arguments for future implementation
-    --------------------------------------------
-    policy_dir : str
-        Directory containing saved RL policy checkpoints.
-    pair_list : list[str]
-        List of trading pairs to evaluate.
+import numpy as np
+import pandas as pd
+from backtesting import Backtest, Strategy
+from ray.rllib.algorithms.algorithm import Algorithm
+
+from ..config import LOG_DIR, PROC_DIR, INIT_CAPITAL, WINDOW_LENGTH, METRICS
+from . import metrics as m
+
+
+def _load_prices(ticker: str) -> pd.Series:
+    """Return a processed price series for ``ticker``."""
+
+    df = pd.read_parquet(PROC_DIR / f"{ticker}.parquet")
+    for col in ["Close", "close", "Adj Close", "adjclose"]:
+        if col in df.columns:
+            return df[col]
+    return df.select_dtypes(include="number").iloc[:, 0]
+
+
+def _load_checkpoint(directory: Path) -> Algorithm:
+    """Load the most recent RLlib checkpoint from ``directory``."""
+
+    candidates = sorted(directory.glob("checkpoint_*/"), reverse=True)
+    if not candidates:
+        raise FileNotFoundError(f"No checkpoint found in {directory}")
+    return Algorithm.from_checkpoint(str(candidates[0]))
+
+
+def run_backtests(
+    policy_dir: str | Path | None = None,
+    pair_list: Iterable[tuple[str, str]] | None = None,
+) -> dict[str, dict[str, float]]:
+    """Run offline backtests for trained policies and return metrics.
+
+    Parameters
+    ----------
+    policy_dir : path-like, optional
+        Directory containing saved RL policy checkpoints. Defaults to ``LOG_DIR``.
+    pair_list : iterable of ``(ticker1, ticker2)`` tuples, optional
+        Pairs to evaluate. If ``None``, the function attempts to load
+        ``pairs.npy`` from ``policy_dir``.
     """
 
-    raise NotImplementedError("Backtesting engine not implemented yet")
+    policy_dir = Path(policy_dir or LOG_DIR)
+
+    if pair_list is None:
+        pairs_file = policy_dir / "pairs.npy"
+        if not pairs_file.exists():
+            print("pairs.npy not found; nothing to backtest.")
+            return {}
+        pair_list = np.load(pairs_file, allow_pickle=True)
+
+    results: dict[str, dict[str, float]] = {}
+
+    for t1, t2 in pair_list:
+        pair_name = f"{t1}-{t2}"
+        ckpt_dir = policy_dir / f"ppo_{t1}_{t2}"
+        try:
+            algo = _load_checkpoint(ckpt_dir)
+        except Exception as e:
+            print(f"Skipping {pair_name}: {e}")
+            continue
+
+        price1 = _load_prices(t1)
+        price2 = _load_prices(t2)
+        spread = price1 - price2
+        df = pd.DataFrame(
+            {
+                "Open": spread,
+                "High": spread,
+                "Low": spread,
+                "Close": spread,
+            }
+        )
+
+        class RLPairStrategy(Strategy):
+            def init(self):
+                self.t = WINDOW_LENGTH
+                self.state = algo.get_initial_state()
+
+            def next(self):
+                if self.t >= len(spread):
+                    return
+                obs = spread.iloc[self.t - WINDOW_LENGTH : self.t].values.astype(
+                    "float32"
+                )
+                action, self.state, _ = algo.compute_single_action(
+                    obs, state=self.state
+                )
+                if action == 1:  # long spread
+                    if not self.position.is_long:
+                        self.position.close()
+                        self.buy()
+                elif action == 2:  # short spread
+                    if not self.position.is_short:
+                        self.position.close()
+                        self.sell()
+                else:  # flat
+                    if self.position:
+                        self.position.close()
+                self.t += 1
+
+        bt = Backtest(
+            df,
+            RLPairStrategy,
+            cash=INIT_CAPITAL,
+            commission=0.0,
+            exclusive_orders=True,
+        )
+
+        stats = bt.run()
+        equity = stats["_equity_curve"]["Equity"]
+        returns = equity.pct_change().dropna()
+        metrics = {name: getattr(m, name)(returns) for name in METRICS}
+        metrics["Final Equity"] = float(equity.iloc[-1])
+        results[pair_name] = metrics
+        print(f"Backtested {pair_name}: {metrics}")
+
+    return results


### PR DESCRIPTION
## Summary
- use Backtesting.py for RL policy backtests
- document new backtesting implementation in README
- add Backtesting.py dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: No matching distribution found for pandas-ta>=0.3)*

------
https://chatgpt.com/codex/tasks/task_e_684201362820832dbc8a10e9cd35ea7f