### PR TITLE
Add SB3 PPO training system

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ python scripts/run_full_pipeline.py
 4. **Cluster securities** using `src.clustering.cluster_utils.cluster_latents`.
 5. **Select pairs** with `src.clustering.select_pairs.select_pairs` from each cluster.
 6. **Train agents** on each pair through `src.rl.train_agent.train_all_pairs`.
+   Alternatively run `scripts/train_agents_sb3.py` to use Stable-Baselines3
+   PPO (``gamma=0.99``).
 7. **Backtest results** with `src.backtest.backtester.run_backtests`.
 
 The RL agent training and backtesting steps currently contain placeholder

--- a/launch_rl_training.sh
+++ b/launch_rl_training.sh
@@ -1,4 +1,7 @@
 
 #!/usr/bin/env bash
 # Example SLURM submission or local launch
+# Default RLlib training
 python -m src.rl.train_agent
+# Or run Stable-Baselines3 PPO
+# python scripts/train_agents_sb3.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ seaborn>=0.13
 tqdm>=4.66
 python-dotenv>=1.0
 optuna>=3.6
+stable-baselines3>=2.3

--- a/scripts/train_agents_sb3.py
+++ b/scripts/train_agents_sb3.py
@@ -1,0 +1,4 @@
+from src.rl.train_sb3 import train_all_pairs_sb3
+
+if __name__ == "__main__":
+    train_all_pairs_sb3()

--- a/src/rl/train_sb3.py
+++ b/src/rl/train_sb3.py
@@ -1,0 +1,66 @@
+"""Training utilities using Stable-Baselines3 PPO."""
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv
+
+from .envs import PairTradingEnv
+from ..config import LOG_DIR, PROC_DIR
+
+
+def _load_prices(ticker: str) -> pd.Series:
+    """Return a price series for ``ticker`` from ``PROC_DIR``."""
+    df = pd.read_parquet(PROC_DIR / f"{ticker}.parquet")
+    for col in ["Close", "close", "Adj Close", "adjclose"]:
+        if col in df.columns:
+            return df[col]
+    return df.select_dtypes(include="number").iloc[:, 0]
+
+
+def train_pair_sb3(
+    t1: str,
+    t2: str,
+    total_timesteps: int = 100_000,
+    gamma: float = 0.99,
+) -> None:
+    """Train PPO on a single ticker pair using SB3."""
+    price1 = _load_prices(t1)
+    price2 = _load_prices(t2)
+
+    def make_env():
+        return PairTradingEnv(price1, price2)
+
+    env = DummyVecEnv([make_env])
+    model = PPO("MlpPolicy", env, gamma=gamma, verbose=1)
+    model.learn(total_timesteps=total_timesteps)
+
+    save_dir = Path(LOG_DIR) / f"sb3_ppo_{t1}_{t2}"
+    save_dir.mkdir(parents=True, exist_ok=True)
+    model.save(str(save_dir / "model"))
+
+
+def train_all_pairs_sb3(
+    pairs: Iterable[tuple[str, str]] | None = None,
+    total_timesteps: int = 100_000,
+    gamma: float = 0.99,
+) -> None:
+    """Train PPO agents with SB3 for each pair listed in ``pairs``."""
+
+    if pairs is None:
+        pairs_file = LOG_DIR / "pairs.npy"
+        if not pairs_file.exists():
+            print("pairs.npy not found; nothing to train.")
+            return
+        pairs = np.load(pairs_file, allow_pickle=True)
+
+    for t1, t2 in pairs:
+        print(f"Training pair {t1}-{t2}")
+        train_pair_sb3(t1, t2, total_timesteps=total_timesteps, gamma=gamma)
+
+
+if __name__ == "__main__":
+    train_all_pairs_sb3()


### PR DESCRIPTION
## Summary
- add Stable-Baselines3 dependency
- implement `train_sb3.py` with PPO training at gamma=0.99
- add script entry point `train_agents_sb3.py`
- update example training launch and README with SB3 option

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m scripts.train_agents_sb3` *(fails gracefully: pairs file not found)*
- `pip install stable-baselines3`

------
https://chatgpt.com/codex/tasks/task_e_684203712ac4832db27d605356e6d00b