### PR TITLE
Improve scaler loading and add safety check

### DIFF
--- a/src/autoencoder/train_cae.py
+++ b/src/autoencoder/train_cae.py
@@ -5,7 +5,7 @@ from sklearn.cluster import KMeans
 from ..config import PROC_DIR, CAE_EPOCHS, CAE_BATCH_SIZE, LOG_DIR, WINDOW_LENGTH, LATENT_DIM
 from .cae_model import build_cae
 from ..data.window_builder import build_windows
-from ..data.scaler import fit_scaler
+from ..data.scaler import load_scaler
 
 
 def _exp_weights(n: int, alpha: float) -> np.ndarray:
@@ -50,7 +50,7 @@ def train_cae(
     History
         Training history returned by ``model.fit``.
     """
-    scaler = fit_scaler()
+    scaler = load_scaler()
     files = sorted(PROC_DIR.glob("*.parquet"))
     dfs = [pd.read_parquet(p) for p in files]
     X = pd.concat(dfs).dropna()


### PR DESCRIPTION
## Summary
- prevent `fit_scaler` from running if processed data directory is empty
- cache the fitted scaler so subsequent CAE training reuses it
- update CAE training to load the cached scaler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842133066c4832dbf9f45c626befb8b