### PR TITLE
Fix ticker level CAE preprocessing

### DIFF
--- a/src/autoencoder/train_cae.py
+++ b/src/autoencoder/train_cae.py
@@ -2,6 +2,7 @@ import json
 import numpy as np
 import pandas as pd
 from sklearn.cluster import KMeans
+from sklearn.preprocessing import StandardScaler
 from ..config import PROC_DIR, CAE_EPOCHS, CAE_BATCH_SIZE, LOG_DIR, WINDOW_LENGTH, LATENT_DIM
 from .cae_model import build_cae
 from ..data.window_builder import build_windows
@@ -52,22 +53,19 @@ def train_cae(
     """
     scaler = fit_scaler()
     files = sorted(PROC_DIR.glob("*.parquet"))
-    dfs = [pd.read_parquet(p) for p in files]
-    X = pd.concat(dfs).dropna()
-    X = scaler.transform(X)
-    n_features = X.shape[1]
-
     windows = []
     lengths = []
-    idx = 0
-    for df in dfs:
+    for p in files:
+        df = pd.read_parquet(p)
+        df = df.dropna()
+        scaled = scaler.transform(df)
         w = build_windows(
-            pd.DataFrame(X[idx: idx + len(df)], index=df.index),
-            window_length
+            pd.DataFrame(scaled, index=df.index),
+            window_length,
         )
         windows.append(w)
         lengths.append(len(w))
-        idx += len(df)
+    n_features = scaler.mean_.shape[0]
     Xw = np.concatenate(windows, axis=0)
 
     model, encoder = build_cae(n_features, window_length, latent_dim)
@@ -106,8 +104,10 @@ def train_cae(
             agg.append(np.concatenate([mean, var]))
         start += l
     ticker_latent = np.stack(agg, axis=0)
+    ticker_latent_scaled = StandardScaler().fit_transform(ticker_latent)
     if save:
         np.save(LOG_DIR / "ticker_latent.npy", ticker_latent)
+        np.save(LOG_DIR / "ticker_latent_scaled.npy", ticker_latent_scaled)
 
     tickers = [p.stem for p in files]
     if save:


### PR DESCRIPTION
## Summary
- drop missing rows per ticker before scaling to prevent misalignment
- apply shared scaler individually on each ticker
- save both raw and standardized ticker representations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421337a174832d90a76c3c4266f933