### PR TITLE
Scale latents before clustering and store scaler

### DIFF
--- a/src/clustering/cluster_utils.py
+++ b/src/clustering/cluster_utils.py
@@ -1,17 +1,34 @@
 
 import numpy as np
+import joblib
 from sklearn.cluster import AgglomerativeClustering
 from sklearn.preprocessing import StandardScaler
 from ..config import N_CLUSTERS, LOG_DIR
 
-def cluster_latents(Z: np.ndarray | None = None, n_clusters: int = N_CLUSTERS, save: bool = True):
+# Default location of the latent vectors produced by the autoencoder
+path = LOG_DIR / "ticker_latent.npy"
+
+def cluster_latents(
+    Z: np.ndarray | None = None, n_clusters: int = N_CLUSTERS, save: bool = True
+):
     """Cluster latent vectors and optionally save the labels."""
+
     save_output = Z is None
     if Z is None:
-        Z = np.load(LOG_DIR / 'ticker_latent.npy')
-    Z = StandardScaler().fit_transform(Z)
-    clust = AgglomerativeClustering(n_clusters=n_clusters, linkage='ward')
-    labels = clust.fit_predict(Z)
+        if not path.exists():
+            raise FileNotFoundError(f"{path} missing – run train_cae() first")
+        Z = np.load(path)
+        scaler = StandardScaler()
+        Zs = scaler.fit_transform(Z)
+        joblib.dump(scaler, LOG_DIR / "cluster_scaler.joblib")
+    else:
+        scaler = StandardScaler()
+        Zs = scaler.fit_transform(Z)
+
+    clust = AgglomerativeClustering(n_clusters=n_clusters, linkage="ward")
+    labels = clust.fit_predict(Zs)
+
     if save and save_output:
-        np.save(LOG_DIR / 'labels.npy', labels)
-    return Z, labels
+        np.save(LOG_DIR / "labels.npy", labels)
+
+    return Zs, labels


### PR DESCRIPTION
## Summary
- ensure clustering raises a clear error when latent file is missing
- scale latent vectors once with `StandardScaler` before clustering
- persist the scaler for later use

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842133eadac832d926882625ad47e4e