### PR TITLE
Fix pair selection with scaled latent space

### DIFF
--- a/src/clustering/select_pairs.py
+++ b/src/clustering/select_pairs.py
@@ -5,17 +5,22 @@ from scipy.spatial.distance import cdist
 from ..config import PAIRS_PER_CLUST, LOG_DIR
 
 def select_pairs():
-    Z = np.load(LOG_DIR / 'ticker_latent.npy')
+    # Load standardized latent vectors for consistent distance calculations
+    Z = np.load(LOG_DIR / 'ticker_latent_scaled.npy')
     labels = np.load(LOG_DIR / 'labels.npy')
     with open(LOG_DIR / 'ticker_index.json') as f:
         tickers = json.load(f)
 
     pairs = []
     for c in set(labels):
-        idx = np.where(labels==c)[0]
+        idx = np.where(labels == c)[0]
+        if len(idx) < 2:
+            print(f"Cluster {c} has <2 tickers; skipped.")
+            continue
+
         dists = cdist(Z[idx], Z[idx], metric='euclidean')
         triu = np.triu_indices_from(dists, k=1)
-        sorted_pairs = sorted(zip(triu[0],triu[1],dists[triu]), key=lambda x:x[2])
+        sorted_pairs = sorted(zip(triu[0], triu[1], dists[triu]), key=lambda x: x[2])
         top = sorted_pairs[:PAIRS_PER_CLUST]
         pairs.extend([(tickers[idx[i]], tickers[idx[j]]) for i, j, _ in top])
 


### PR DESCRIPTION
## Summary
- load standardized latent vectors before pair selection
- skip clusters with fewer than two tickers to avoid crashes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68421348c694832dbbb8b7716afaa7c8