### PR TITLE
Add quick start instructions and diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,21 @@
 
 End‑to‑end research pipeline that discovers statistical‑arbitrage pairs in the S&P 500, clusters them with a convolutional auto‑encoder (CAE), and trains a PPO agent (Ray RLlib) to trade each pair with **$1 000** initial capital.
 
-## Quick start
+## Quick Start
+
+Clone the repository, install the Python dependencies and run the pipeline:
 
 ```bash
-git clone <your‑fork> pairs
+git clone <your-fork> pairs
 cd pairs
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-python scripts/optimize_hyperparams.py  # optional hyperparameter tuning
 python scripts/run_full_pipeline.py
 ```
+
+This single command downloads data, trains the ML models and runs a
+backtest. A Mermaid diagram describing how each module connects is available in
+[docs/pipeline_flow.html](docs/pipeline_flow.html).
 ### Repository layout
 - `src/` – production Python package with submodules for data, autoencoder, clustering, RL and backtesting
 - `scripts/` – entry points and utilities

--- a/docs/pipeline_flow.html
+++ b/docs/pipeline_flow.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Pairs-Trading Pipeline</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+</head>
+<body>
+<h2>Data and ML Flow</h2>
+<div class="mermaid">
+  graph TD
+    A[Download Data] --> B[Feature Engineering]
+    B --> C[Train CAE]
+    C --> D[Cluster Latents]
+    D --> E[Select Pairs]
+    E --> F[Train RL Agents]
+    F --> G[Backtest Results]
+</div>
+<script>
+mermaid.initialize({ startOnLoad: true });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add "Quick Start" directions
- include a mermaid diagram under docs/pipeline_flow.html

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684215f991e0832d9ccc40878f8afc98