### PR TITLE
Fix fundamental resampling

### DIFF
--- a/src/data/feature_engineer.py
+++ b/src/data/feature_engineer.py
@@ -15,9 +15,12 @@ def engineer(ticker:str):
         enforce_source="YahooFinance",
     )
 
-    funda = tk.ratios.collect().ffill()
+    funda = tk.ratios.collect()
+    # Up-sample quarterly fundamentals to business days and
+    # interpolate between reporting dates
+    funda = (funda.resample("B").interpolate().ffill()
+                   .reindex(df.index).ffill())
 
-    df = df.reindex(funda.index).ffill()
     df = pd.concat([df, funda], axis=1).dropna()
     out = PROC_DIR/f"{ticker}.parquet"
     out.parent.mkdir(parents=True,exist_ok=True)


### PR DESCRIPTION
## Summary
- interpolate quarterly fundamentals to business days before merging price data

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68421faf07a8832dbf0891fefc940655