### PR TITLE
Switch to Calinski-Harabasz metric in hyperparameter optimization

### DIFF
--- a/scripts/optimize_hyperparams.py
+++ b/scripts/optimize_hyperparams.py
@@ -2,7 +2,7 @@
 
 import optuna
 import tensorflow as tf
-from sklearn.metrics import silhouette_score
+from sklearn.metrics import calinski_harabasz_score
 from src.autoencoder.train_cae import train_cae
 from src.clustering.cluster_utils import cluster_latents
 from src.config import LOG_DIR
@@ -21,7 +21,7 @@ def objective(trial: optuna.Trial) -> float:
             callbacks=[tf.keras.callbacks.EarlyStopping(patience=10, restore_best_weights=True)],
         )
         _, labels = cluster_latents(ticker_latent, n_clusters=n_clusters, save=False)
-        score = silhouette_score(ticker_latent, labels)
+        score = calinski_harabasz_score(ticker_latent, labels)
         return -float(score)
     except Exception as exc:
         print(f"Trial failed: {exc}")


### PR DESCRIPTION
## Summary
- replace `silhouette_score` with `calinski_harabasz_score` in `scripts/optimize_hyperparams.py`

## Testing
- `python -m py_compile scripts/optimize_hyperparams.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422052efe0832d94f0064c93b5c024