### PR TITLE
Document and compute new hedge ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,17 @@ experiments. Backtests leverage **Backtesting.py** via
 metrics is provided in `src.backtest.metrics`.
 
 ---
+
+### Hedge Ratio Definition
+
+The system uses a volatility- and correlation-adjusted hedge ratio.  Given two
+price series ``A`` and ``B`` the ratio is
+
+``beta = rho * sigma_A / sigma_B``
+
+where ``rho`` is the correlation between the expected price changes
+``ΔA`` and ``ΔB`` and ``sigma_A``/``sigma_B`` are the standard deviations of
+those changes.  This value indicates how many shares of the short leg (``B``)
+neutralize the price risk in the long leg (``A``), allowing the spread to
+capture relative mispricing rather than market drift.
+

--- a/src/rl/envs.py
+++ b/src/rl/envs.py
@@ -1,8 +1,11 @@
+"""RL trading environments."""
+
 import gymnasium as gym
 from gymnasium import spaces
 import numpy as np
 import pandas as pd
 from ..config import INIT_CAPITAL, WINDOW_LENGTH, SWITCH_PENALTY
+from .hedge_utils import calc_hedge_ratio
 
 
 class PairTradingEnv(gym.Env):
@@ -17,8 +20,11 @@ class PairTradingEnv(gym.Env):
         price1_series, price2_series : pandas.Series
             Synchronized price series of the two assets.
         hedge_ratio : array-like or callable, optional
-            Static array of hedge ratios or a function ``f(t)`` returning
-            the ratio at index ``t``.  Defaults to 1.
+            Static array of hedge ratios or a function ``f(t)`` returning the
+            ratio at index ``t``.  If ``None`` the ratio is estimated as
+            ``rho * sigma_A / sigma_B`` where ``rho`` is the correlation between
+            ``Δprice1`` and ``Δprice2`` and ``sigma_A``/``sigma_B`` are their
+            respective standard deviations.
         """
         super().__init__()
 
@@ -35,7 +41,8 @@ class PairTradingEnv(gym.Env):
                 raise ValueError("hedge_ratio length must match price series length")
             self._hr_fn, self._hr_arr = None, hr
         else:
-            self._hr_fn, self._hr_arr = None, np.ones_like(self.price1)
+            hr = calc_hedge_ratio(price1_series, price2_series)
+            self._hr_fn, self._hr_arr = None, np.full_like(self.price1, hr, dtype=float)
 
         # Action mapping: 0 = short spread, 1 = flat, 2 = long spread
         self.action_space = spaces.Discrete(3)

--- a/src/rl/hedge_utils.py
+++ b/src/rl/hedge_utils.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pandas as pd
+
+
+def calc_hedge_ratio(price1: pd.Series, price2: pd.Series) -> float:
+    """Return hedge ratio using correlation-adjusted volatility scaling.
+
+    The hedge ratio quantifies how many shares of ``price2`` are required to
+    neutralize price risk in ``price1``. It equals ``rho * sigma_A / sigma_B``
+    where ``rho`` is the correlation between ``Δprice1`` and ``Δprice2``,
+    ``sigma_A`` is the standard deviation of ``Δprice1`` and ``sigma_B`` the
+    standard deviation of ``Δprice2``.
+    """
+    d1 = price1.diff().dropna()
+    d2 = price2.diff().dropna()
+    if len(d1) == 0 or len(d2) == 0:
+        raise ValueError("price series must contain at least two observations")
+
+    rho = np.corrcoef(d1, d2)[0, 1]
+    sigma_a = np.std(d1, ddof=1)
+    sigma_b = np.std(d2, ddof=1)
+    return float(rho * sigma_a / sigma_b)


### PR DESCRIPTION
## Summary
- add volatility+correlation hedge ratio documentation
- compute default hedge ratio via `calc_hedge_ratio`
- expose helper in `src/rl/hedge_utils.py`

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_68424acf5de4832d94057967657859bf