### PR TITLE
Add LSTM-based recurrent policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Pairs‑Trading System (Deep RL + Clustering)
 
-End‑to‑end research pipeline that discovers statistical‑arbitrage pairs in the S&P 500, clusters them with a convolutional auto‑encoder (CAE), and trains a PPO agent (Ray RLlib) to trade each pair with **$1 000** initial capital.
+End‑to‑end research pipeline that discovers statistical‑arbitrage pairs in the S&P 500, clusters them with a convolutional auto‑encoder (CAE), and trains a PPO agent (Ray RLlib) to trade each pair with **$1 000** initial capital. The RL agent now employs an LSTM‑based recurrent policy and critic so that past observations influence current decisions.
 
 ## Quick Start
 
@@ -30,8 +30,9 @@ backtest. A Mermaid diagram describing how each module connects is available in
 4. **Cluster securities** using `src.clustering.cluster_utils.cluster_latents`.
 5. **Select pairs** with `src.clustering.select_pairs.select_pairs` from each cluster.
 6. **Train agents** on each pair through `src.rl.train_agent.train_all_pairs`.
-   Alternatively run `scripts/train_agents_sb3.py` to use Stable-Baselines3
-   PPO (``gamma=0.99``).
+   The policy and value networks use an LSTM backbone so previous observations
+   are carried across timesteps. Alternatively run `scripts/train_agents_sb3.py`
+   to use Stable-Baselines3 PPO (``gamma=0.99``).
 7. **Backtest results** with `src.backtest.backtester.run_backtests`.
 
 The RL training script uses a lightweight configuration suitable for quick

--- a/src/rl/train_agent.py
+++ b/src/rl/train_agent.py
@@ -11,7 +11,7 @@ import logging
 from ray.rllib.algorithms.ppo import PPO
 
 from .envs import PairTradingEnv
-from ..config import LOG_DIR, PROC_DIR, NUM_WORKERS
+from ..config import LOG_DIR, PROC_DIR, NUM_WORKERS, WINDOW_LENGTH
 
 logging.basicConfig(format="%(asctime)s %(levelname)s:%(message)s", level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -44,6 +44,13 @@ def _train_pair(t1: str, t2: str) -> None:
             "framework": "torch",
             "num_workers": NUM_WORKERS,
             "train_batch_size": 4000,
+            # Use an LSTM-based policy and value network to retain a hidden state
+            # of previous observations when optimising the policy and Q-values.
+            "model": {
+                "use_lstm": True,
+                "max_seq_len": WINDOW_LENGTH,
+                "lstm_cell_size": 128,
+            },
         },
     )
 


### PR DESCRIPTION
## Summary
- describe RL agent uses an LSTM-based policy and critic
- enable LSTM support in PPO training
- document new behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68424c7a8988832db1bc044e72bbaf07