### PR TITLE
Add basic tests for core modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the src package is importable
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_cae_model.py
+++ b/tests/test_cae_model.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pytest
+pytest.importorskip('tensorflow')
+
+from src.autoencoder.cae_model import build_cae
+
+
+def test_build_cae_forward_pass():
+    model, encoder = build_cae(n_features=2, window_length=4, latent_dim=2)
+    x = np.random.rand(1, 4, 2).astype(np.float32)
+    out = model.predict(x)
+    assert out.shape == x.shape
+    latent = encoder.predict(x)
+    assert latent.shape == (1, 2)

--- a/tests/test_cluster_utils.py
+++ b/tests/test_cluster_utils.py
@@ -1,0 +1,13 @@
+import numpy as np
+from src import config
+from src.clustering import cluster_utils
+
+
+def test_cluster_latents(tmp_path, monkeypatch):
+    data = np.random.rand(10, 4)
+    monkeypatch.setattr(config, "LOG_DIR", tmp_path)
+    # patch module-level LOG_DIR if present
+    monkeypatch.setattr(cluster_utils, "LOG_DIR", tmp_path)
+    Zs, labels = cluster_utils.cluster_latents(data, n_clusters=2, save=True)
+    assert Zs.shape == data.shape
+    assert len(labels) == 10

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pandas as pd
+import importlib
+import pytest
+
+pytest.importorskip('gymnasium')
+
+from src.rl.envs import PairTradingEnv
+
+
+def test_env_basic_step():
+    price1 = pd.Series(np.arange(10, dtype=float))
+    price2 = pd.Series(np.arange(10, dtype=float))
+    env = PairTradingEnv(price1, price2)
+    obs, _ = env.reset()
+    assert obs.shape[0] == env.observation_space.shape[0]
+    obs, reward, done, trunc, info = env.step(1)
+    assert isinstance(reward, float)
+    assert obs.shape == env.observation_space.shape

--- a/tests/test_hedge_utils.py
+++ b/tests/test_hedge_utils.py
@@ -1,0 +1,10 @@
+import numpy as np
+import pandas as pd
+from src.rl.hedge_utils import calc_hedge_ratio
+
+
+def test_calc_hedge_ratio():
+    price1 = pd.Series([1, 2, 4, 7, 11], dtype=float)
+    price2 = pd.Series([2, 4, 8, 14, 22], dtype=float)
+    ratio = calc_hedge_ratio(price1, price2)
+    assert np.isclose(ratio, 0.5)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,15 @@
+import numpy as np
+from src.backtest import metrics
+
+
+def test_sharpe_and_others():
+    returns = np.array([0.01, -0.02, 0.03, -0.01])
+    bench = np.array([0.02, -0.01, 0.01, 0.0])
+    assert np.isfinite(metrics.sharpe(returns))
+    assert np.isfinite(metrics.total_pnl(returns))
+    assert np.isfinite(metrics.annual_return(returns))
+    assert np.isfinite(metrics.beta(returns, bench))
+    assert np.isfinite(metrics.alpha(returns, bench))
+    assert np.isfinite(metrics.max_drawdown(returns))
+    assert np.isfinite(metrics.sortino(returns))
+    assert np.isfinite(metrics.calmar(returns))

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import numpy as np
+import importlib
+
+from src import config
+from src.data import scaler as scaler_mod
+
+
+def test_fit_and_load_scaler(tmp_path, monkeypatch):
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    df = pd.DataFrame({"a": [1,2,3,4], "b": [4,3,2,1]})
+    for i in range(2):
+        df.to_parquet(proc / f"t{i}.parquet")
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(config, "PROC_DIR", proc)
+    monkeypatch.setattr(config, "LOG_DIR", log_dir)
+    monkeypatch.setattr(scaler_mod, "PROC_DIR", proc)
+    monkeypatch.setattr(scaler_mod, "LOG_DIR", log_dir)
+    scaler = scaler_mod.fit_scaler()
+    assert scaler.mean_.shape[0] == 2
+    loaded = scaler_mod.load_scaler()
+    assert np.allclose(loaded.mean_, scaler.mean_)

--- a/tests/test_select_pairs.py
+++ b/tests/test_select_pairs.py
@@ -1,0 +1,16 @@
+import numpy as np
+import json
+from src import config
+from src.clustering import select_pairs as sp
+
+
+def test_select_pairs(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(sp, "LOG_DIR", tmp_path)
+    np.save(tmp_path / "ticker_latent_scaled.npy", np.random.rand(4, 3))
+    np.save(tmp_path / "labels.npy", np.array([0, 0, 1, 1]))
+    with open(tmp_path / "ticker_index.json", "w") as f:
+        json.dump(["A", "B", "C", "D"], f)
+    pairs = sp.select_pairs()
+    assert isinstance(pairs, list)
+    assert (tmp_path / "pairs.npy").exists()

--- a/tests/test_window_builder.py
+++ b/tests/test_window_builder.py
@@ -1,0 +1,10 @@
+import numpy as np
+import pandas as pd
+from src.data.window_builder import build_windows
+
+
+def test_build_windows_basic():
+    df = pd.DataFrame({'a': [1, 2, 3, 4, 5], 'b': [5, 4, 3, 2, 1]})
+    windows = build_windows(df, window_length=3)
+    assert windows.shape == (2, 3, 2)
+    np.testing.assert_array_equal(windows[0], df.iloc[0:3].values)


### PR DESCRIPTION
## Summary
- add pytest configuration and test coverage for data processing, clustering, metrics and env utilities
- ensure tests adjust configuration paths so no real data is required

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424de47810832dab5beb424553c94d