### PR TITLE
Fix requirements formatting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-
 pandas>=2.2
 numpy>=1.26
 yfinance>=0.2
 financetoolkit>=2.0
-pandas-ta>=0.3
+pandas-ta==0.3.14b0
 scikit-learn>=1.5
 tensorflow>=2.16
 ray[rllib]>=2.10


### PR DESCRIPTION
## Summary
- pin `pandas-ta` to version `0.3.14b0`
- remove the leading blank line in `requirements.txt`
- ensure file ends with newline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68427c002c34832dab1f2a1bb597e9f6