### PR TITLE
Add fail-fast preflight checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ pip install -r requirements.txt
 python scripts/run_full_pipeline.py
 ```
 
+The pipeline performs basic pre-flight checks and stops on the first
+failing stage so errors are visible immediately.
+
 This single command downloads data, trains the ML models and runs a
 backtest. A Mermaid diagram describing how each module connects is available in
 [docs/pipeline_flow.html](docs/pipeline_flow.html).

--- a/launch_rl_training.sh
+++ b/launch_rl_training.sh
@@ -1,6 +1,7 @@
 
 #!/usr/bin/env bash
 # Example SLURM submission or local launch
+set -euo pipefail
 # Default RLlib training
 python -m src.rl.train_agent
 # Or run Stable-Baselines3 PPO

--- a/scripts/optimize_hyperparams.py
+++ b/scripts/optimize_hyperparams.py
@@ -3,6 +3,7 @@
 import optuna
 import tensorflow as tf
 from sklearn.metrics import calinski_harabasz_score
+from src.preflight import run_checks
 from src.autoencoder.train_cae import train_cae
 from src.clustering.cluster_utils import cluster_latents
 from src.config import LOG_DIR
@@ -29,6 +30,8 @@ def objective(trial: optuna.Trial) -> float:
 
 
 def main() -> None:
+    run_checks()
+
     study = optuna.create_study()
     study.optimize(objective, n_trials=10)
     study.trials_dataframe().to_csv(LOG_DIR/"optuna_trials.csv", index=False)

--- a/scripts/train_agents_sb3.py
+++ b/scripts/train_agents_sb3.py
@@ -1,4 +1,6 @@
 from src.rl.train_sb3 import train_all_pairs_sb3
+from src.preflight import run_checks
 
 if __name__ == "__main__":
+    run_checks()
     train_all_pairs_sb3()

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from .config import TICKER_FILE
+
+
+def run_checks() -> None:
+    """Ensure environment is ready before running scripts."""
+    if sys.version_info < (3, 10):
+        sys.exit("Python 3.10 or higher is required")
+
+    if not Path(TICKER_FILE).exists():
+        sys.exit(f"Ticker file {TICKER_FILE} not found")

--- a/src/rl/train_agent.py
+++ b/src/rl/train_agent.py
@@ -85,4 +85,7 @@ def train_all_pairs(pairs: Iterable[tuple[str, str]] | None = None) -> None:
 
 
 if __name__ == "__main__":
+    from ..preflight import run_checks
+
+    run_checks()
     train_all_pairs()

--- a/src/rl/train_sb3.py
+++ b/src/rl/train_sb3.py
@@ -63,4 +63,7 @@ def train_all_pairs_sb3(
 
 
 if __name__ == "__main__":
+    from ..preflight import run_checks
+
+    run_checks()
     train_all_pairs_sb3()


### PR DESCRIPTION
## Summary
- add a `preflight` module for environment checks
- stop pipeline execution on first failure
- ensure training scripts run preflight checks
- enforce bash safety flags
- document new behavior in README

## Testing
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68427fbd00e8832d9298a6119622ae0a