### PR TITLE
Fix RAW_DIR creation in downloader batch

### DIFF
--- a/src/data/downloader.py
+++ b/src/data/downloader.py
@@ -26,6 +26,7 @@ def batch():
           .dropna()
           .tolist()
     )
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
     for t in tickers:
         print('↓',t)
         download(t.strip())


### PR DESCRIPTION
## Summary
- ensure the raw data directory exists when running `downloader.batch`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b7494ac4832d84bd43b8a1f436da