### PR TITLE
Update pair selector and env window logic

### DIFF
--- a/src/clustering/select_pairs.py
+++ b/src/clustering/select_pairs.py
@@ -21,7 +21,7 @@ def select_pairs():
         dists = cdist(Z[idx], Z[idx], metric='euclidean')
         triu = np.triu_indices_from(dists, k=1)
         sorted_pairs = sorted(zip(triu[0], triu[1], dists[triu]), key=lambda x: x[2])
-        top = sorted_pairs[:PAIRS_PER_CLUST]
+        top = sorted_pairs[:min(PAIRS_PER_CLUST, len(sorted_pairs))]
         pairs.extend([(tickers[idx[i]], tickers[idx[j]]) for i, j, _ in top])
 
     # Save as numpy array of strings for later steps

--- a/src/rl/envs.py
+++ b/src/rl/envs.py
@@ -32,6 +32,7 @@ class PairTradingEnv(gym.Env):
         # Cache prices as numpy for speed
         self.price1 = price1_series.values
         self.price2 = price2_series.values
+        self.window_length = min(WINDOW_LENGTH, len(self.price1))
 
         # Handle hedge-ratio input
         if callable(hedge_ratio):
@@ -48,16 +49,16 @@ class PairTradingEnv(gym.Env):
         # Action mapping: 0 = short spread, 1 = flat, 2 = long spread
         self.action_space = spaces.Discrete(3)
 
-        # Observation = last WINDOW_LENGTH normalised spread values
+        # Observation = last `window_length` normalised spread values
         self.observation_space = spaces.Box(
-            low=-np.inf, high=np.inf, shape=(WINDOW_LENGTH,), dtype=np.float32
+            low=-np.inf, high=np.inf, shape=(self.window_length,), dtype=np.float32
         )
 
         # Internal state
         self.position = 0            # −1 short, 0 flat, +1 long
         self.capital  = INIT_CAPITAL
         self.stop_loss = STOP_LOSS_LEVEL
-        self.t        = WINDOW_LENGTH
+        self.t        = self.window_length
         self.prev_hr  = self._get_hr(self.t - 1)
 
     # --------------------------------------------------------------------- #
@@ -67,12 +68,16 @@ class PairTradingEnv(gym.Env):
         return self._hr_fn(idx) if self._hr_fn is not None else self._hr_arr[idx]
 
     def _get_hr_array(self, start: int, end: int):
+        start = max(start, 0)
+        end = min(end, len(self._hr_arr))
         if self._hr_fn is not None:
             return np.array([self._hr_fn(i) for i in range(start, end)])
         return self._hr_arr[start:end]
 
     def _compute_spread(self, start: int, end: int):
         """Return normalised spread for the window [start, end)."""
+        start = max(start, 0)
+        end = min(end, len(self.price1))
         hr      = self._get_hr_array(start, end)
         spread  = self.price1[start:end] - hr * self.price2[start:end]
         denom   = max(abs(spread[0]), 1e-6)           # avoid /0
@@ -94,8 +99,9 @@ class PairTradingEnv(gym.Env):
         done = self.t >= len(self.price1)
 
         # Current spread (use *current* hedge ratio)
-        self.prev_hr = self._get_hr(self.t - 1)
-        curr_spread  = self.price1[self.t - 1] - self.prev_hr * self.price2[self.t - 1]
+        idx = min(self.t - 1, len(self.price1) - 1)
+        self.prev_hr = self._get_hr(idx)
+        curr_spread  = self.price1[idx] - self.prev_hr * self.price2[idx]
 
         # PnL for this step, scaled by |prev_spread| to keep rewards magnitude-stable
         pnl     = self.position * (curr_spread - prev_spread)
@@ -111,11 +117,15 @@ class PairTradingEnv(gym.Env):
             self.position = 0
             done = True
             info = {"pnl": pnl, "stop_loss": True}
-            obs = self._compute_spread(self.t - WINDOW_LENGTH, self.t)
+            end = min(self.t, len(self.price1))
+            start = max(end - self.window_length, 0)
+            obs = self._compute_spread(start, end)
             return obs.astype(np.float32), reward, done, False, info
 
-        # Observation = most-recent WINDOW_LENGTH normalised spreads
-        obs = self._compute_spread(self.t - WINDOW_LENGTH, self.t)
+        # Observation = most-recent `window_length` normalised spreads
+        end = min(self.t, len(self.price1))
+        start = max(end - self.window_length, 0)
+        obs = self._compute_spread(start, end)
 
         info = {"pnl": pnl, "stop_loss": False}
         return obs.astype(np.float32), reward, done, False, info
@@ -125,7 +135,7 @@ class PairTradingEnv(gym.Env):
         self.position = 0
         self.capital  = INIT_CAPITAL
         self.stop_loss = STOP_LOSS_LEVEL
-        self.t        = WINDOW_LENGTH
+        self.t        = self.window_length
         self.prev_hr  = self._get_hr(self.t - 1)
         obs = self._compute_spread(0, self.t)
         return obs.astype(np.float32), {}


### PR DESCRIPTION
## Summary
- ensure pair selection handles small clusters
- adjust env window length to avoid index errors on short series
- improve `_compute_spread` and hr access to clip indexes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b78dc714832d952ec0c8be8aebda