### PR TITLE
Add PPO early stopping based on rolling Sharpe

### DIFF
--- a/src/rl/train_agent.py
+++ b/src/rl/train_agent.py
@@ -10,11 +10,19 @@ import ray
 import logging
 from ray.rllib.algorithms.ppo import PPO
 
+from ..backtest import metrics
+
 from .envs import PairTradingEnv
 from ..config import LOG_DIR, PROC_DIR, NUM_WORKERS, WINDOW_LENGTH
 
 logging.basicConfig(format="%(asctime)s %(levelname)s:%(message)s", level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+# Early stopping parameters
+TEST_FRACTION = 0.2     # fraction of data used for evaluation
+MAX_ITERS = 100         # hard cap on training iterations
+PATIENCE = 5            # window size for plateau detection
+TOLERANCE = 0.01        # minimum Sharpe improvement to continue
 
 
 def _load_prices(ticker: str) -> pd.Series:
@@ -32,12 +40,18 @@ def _load_prices(ticker: str) -> pd.Series:
 
 
 def _train_pair(t1: str, t2: str) -> None:
-    """Train a PPO agent for a single pair of tickers."""
+    """Train a PPO agent for a single pair of tickers with early stopping."""
 
-    env_cls = lambda cfg: PairTradingEnv(
-        _load_prices(t1),
-        _load_prices(t2),
-    )
+    price1 = _load_prices(t1)
+    price2 = _load_prices(t2)
+
+    split = int(len(price1) * (1 - TEST_FRACTION))
+    train1, test1 = price1.iloc[:split], price1.iloc[split:]
+    train2, test2 = price2.iloc[:split], price2.iloc[split:]
+
+    env_cls = lambda cfg: PairTradingEnv(train1, train2)
+    eval_env = PairTradingEnv(test1, test2)
+
     trainer = PPO(
         env=env_cls,
         config={
@@ -54,9 +68,34 @@ def _train_pair(t1: str, t2: str) -> None:
         },
     )
 
-    for _ in range(10):
+    def _evaluate() -> float:
+        obs, _ = eval_env.reset()
+        state = trainer.get_policy().get_initial_state()
+        done = False
+        rewards = []
+        while not done:
+            action, state, _ = trainer.compute_single_action(obs, state=state)
+            obs, _, done, _, info = eval_env.step(action)
+            rewards.append(info["pnl"])
+        return metrics.sharpe(np.array(rewards)) if rewards else 0.0
+
+    sharpes: list[float] = []
+    for i in range(MAX_ITERS):
         result = trainer.train()
-        logger.info(f"{t1}-{t2}: {result['episode_reward_mean']}")
+        test_sharpe = _evaluate()
+        sharpes.append(test_sharpe)
+        logger.info(
+            f"{t1}-{t2} iter {i}: reward {result['episode_reward_mean']:.3f} test Sharpe {test_sharpe:.3f}"
+        )
+
+        if len(sharpes) >= 2 * PATIENCE:
+            prev = np.mean(sharpes[-2 * PATIENCE : -PATIENCE])
+            curr = np.mean(sharpes[-PATIENCE:])
+            if curr - prev < TOLERANCE:
+                logger.info(
+                    f"Early stopping at iter {i}: Sharpe plateaued at {curr:.3f}"
+                )
+                break
 
     checkpoint = trainer.save(LOG_DIR / f"{t1}_{t2}")
     trainer.cleanup()


### PR DESCRIPTION
## Summary
- monitor test Sharpe ratio during PPO training
- stop training when average Sharpe no longer improves

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b8a5e15c832db6cdd3d98ce91618