### PR TITLE
Add ADF cointegration check to pair selection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ python-dotenv>=1.0
 optuna>=3.6
 stable-baselines3>=2.3
 backtesting>=0.3.3
+statsmodels>=0.14

--- a/src/clustering/select_pairs.py
+++ b/src/clustering/select_pairs.py
@@ -1,8 +1,29 @@
-
 import json
 import numpy as np
+import pandas as pd
 from scipy.spatial.distance import cdist
-from ..config import PAIRS_PER_CLUST, LOG_DIR
+from statsmodels.tsa.stattools import adfuller
+from ..config import PAIRS_PER_CLUST, LOG_DIR, PROC_DIR
+
+
+def _load_prices(ticker: str) -> pd.Series:
+    """Return a price series for ``ticker`` from ``PROC_DIR``."""
+    df = pd.read_parquet(PROC_DIR / f"{ticker}.parquet")
+    for col in ["Close", "close", "Adj Close", "adjclose"]:
+        if col in df.columns:
+            return df[col]
+    return df.select_dtypes(include="number").iloc[:, 0]
+
+
+def _is_cointegrated(t1: str, t2: str, alpha: float = 0.05) -> bool:
+    """Return ``True`` if the ADF p-value of ``t1``-``t2`` is below ``alpha``."""
+    try:
+        price1 = _load_prices(t1)
+        price2 = _load_prices(t2)
+        pval = adfuller(price1 - price2)[1]
+    except Exception:
+        return False
+    return pval < alpha
 
 def select_pairs():
     # Load standardized latent vectors for consistent distance calculations
@@ -18,11 +39,18 @@ def select_pairs():
             print(f"Cluster {c} has <2 tickers; skipped.")
             continue
 
-        dists = cdist(Z[idx], Z[idx], metric='euclidean')
+        dists = cdist(Z[idx], Z[idx], metric="euclidean")
         triu = np.triu_indices_from(dists, k=1)
         sorted_pairs = sorted(zip(triu[0], triu[1], dists[triu]), key=lambda x: x[2])
-        top = sorted_pairs[:PAIRS_PER_CLUST]
-        pairs.extend([(tickers[idx[i]], tickers[idx[j]]) for i, j, _ in top])
+
+        count = 0
+        for i, j, _ in sorted_pairs:
+            if count >= PAIRS_PER_CLUST:
+                break
+            t1, t2 = tickers[idx[i]], tickers[idx[j]]
+            if _is_cointegrated(t1, t2):
+                pairs.append((t1, t2))
+                count += 1
 
     # Save as numpy array of strings for later steps
     np.save(LOG_DIR / 'pairs.npy', np.array(pairs, dtype=object))

--- a/tests/test_select_pairs.py
+++ b/tests/test_select_pairs.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import json
 from src import config
 from src.clustering import select_pairs as sp
@@ -7,10 +8,27 @@ from src.clustering import select_pairs as sp
 def test_select_pairs(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "LOG_DIR", tmp_path)
     monkeypatch.setattr(sp, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(config, "PROC_DIR", tmp_path)
+    monkeypatch.setattr(sp, "PROC_DIR", tmp_path)
+    monkeypatch.setattr(config, "PAIRS_PER_CLUST", 2)
+    monkeypatch.setattr(sp, "PAIRS_PER_CLUST", 2)
+
     np.save(tmp_path / "ticker_latent_scaled.npy", np.random.rand(4, 3))
-    np.save(tmp_path / "labels.npy", np.array([0, 0, 1, 1]))
+    np.save(tmp_path / "labels.npy", np.array([0, 0, 0, 0]))
     with open(tmp_path / "ticker_index.json", "w") as f:
         json.dump(["A", "B", "C", "D"], f)
+
+    rng = np.random.default_rng(0)
+    prices = {
+        "A": rng.normal(size=100).cumsum(),
+        "B": None,
+        "C": rng.normal(size=100).cumsum(),
+        "D": rng.normal(size=100).cumsum(),
+    }
+    prices["B"] = prices["A"] + rng.normal(scale=0.01, size=100)
+    for t, p in prices.items():
+        pd.DataFrame({"Close": p}).to_parquet(tmp_path / f"{t}.parquet")
+
     pairs = sp.select_pairs()
-    assert isinstance(pairs, list)
+    assert ("A", "B") in pairs
     assert (tmp_path / "pairs.npy").exists()


### PR DESCRIPTION
## Summary
- ensure latent pair selection also filters by Augmented-Dickey–Fuller cointegration
- add unit test for the new selection logic
- include statsmodels in the requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b873c81c832db2d17c8ca22ae0c0