### PR TITLE
Add GitHub CI and pin RL libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+      - name: Run tests
+        run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ financetoolkit>=2.0
 pandas-ta==0.3.14b0
 scikit-learn>=1.5
 tensorflow>=2.16
-ray[rllib]>=2.10
-gymnasium>=0.29
+ray[rllib]==2.10.0
+gymnasium==0.28.1
 scipy>=1.11
 matplotlib>=3.9
 seaborn>=0.13


### PR DESCRIPTION
## Summary
- add CI pipeline running pytest
- pin gymnasium and ray to specific versions

## Testing
- `pip install -r requirements.txt pytest` *(fails: building wheel for `peewee` canceled)*
- `pytest -q tests` *(errors: missing modules like numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6843b7eb8588832d8dd3396c73855300